### PR TITLE
PHP7 - Update composer.json values

### DIFF
--- a/argusdashboard/composer.json
+++ b/argusdashboard/composer.json
@@ -7,7 +7,7 @@
         "psr-0": { "": "src/", "SymfonyStandard": "app/" }
     },
     "require": {
-        "php"                                  : ">=5.6.8",
+        "php"                                  : ">=7.2.0",
         "ext-pdo_sqlite"                       : "*",
         "doctrine/doctrine-bundle"             : "~1.5",
         "doctrine/doctrine-fixtures-bundle"    : "~2.2",
@@ -20,7 +20,7 @@
         "sensio/distribution-bundle"           : "~3.0.28",
         "sensio/framework-extra-bundle"        : "~3.0",
         "symfony/assetic-bundle"               : "~2.6",
-        "symfony/monolog-bundle"               : "~2.7",
+        "symfony/monolog-bundle"               : "~3.0",
         "symfony/swiftmailer-bundle"           : "~2.3",
         "symfony/symfony"                      : "~2.7",
         "jms/serializer-bundle"                : "~1.0",

--- a/argusdashboardreports/lib/PhpReports/ReportValue.php
+++ b/argusdashboardreports/lib/PhpReports/ReportValue.php
@@ -24,7 +24,7 @@ class ReportValue {
 		$this->is_html = false;
 		$this->class = '';
 		
-		$this->type = $this->_getType();
+		$this->type = $this->_getType($value);
 	}
 	
 	public function addClass($class) {
@@ -44,7 +44,7 @@ class ReportValue {
 			$this->html_value = $value;
 		}
 		
-		$this->type = $this->_getType();
+		$this->type = $this->_getType($value);
 	}
 	
 	protected function _getType($value) {


### PR DESCRIPTION
Updated the PHP version to 7.2.0.
The component "symfony/monolog-bundle" needs to be updated to at least version 3.0 in order to fix an issue concerning the count() function which behavior has changed since PHP 7.2.0.