### PR TITLE
PHP7 - Updated calls of _getType() function

### DIFF
--- a/argusdashboardreports/lib/PhpReports/ReportValue.php
+++ b/argusdashboardreports/lib/PhpReports/ReportValue.php
@@ -24,7 +24,7 @@ class ReportValue {
 		$this->is_html = false;
 		$this->class = '';
 		
-		$this->type = $this->_getType();
+		$this->type = $this->_getType($value);
 	}
 	
 	public function addClass($class) {
@@ -44,7 +44,7 @@ class ReportValue {
 			$this->html_value = $value;
 		}
 		
-		$this->type = $this->_getType();
+		$this->type = $this->_getType($value);
 	}
 	
 	protected function _getType($value) {


### PR DESCRIPTION
Sometime the function was called with no parameter, but it is defined with one mandatory parameter, it was causing an error.
It has been fixed.